### PR TITLE
Charts now show results

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -2,4 +2,7 @@ class Answer < ActiveRecord::Base
   belongs_to :question
   has_many :results, dependent: :destroy
   #TODO: make a validation for having at least two answer but reject the blank ones.
+  def to_s
+    content
+  end
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -38,4 +38,8 @@ class Question < ActiveRecord::Base
   def days_left
     (duedate - Date.today).to_i
   end
+
+  def result_data
+    results.includes(:answer).group(:answer).count
+  end
 end

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -11,9 +11,9 @@
   <div class="row">
     <div class="large-8 columns">
       <% if @question.multiple_choice? %>
-        <%= pie_chart @question.results.group(:answer_id).count %>
+        <%= pie_chart @question.result_data %>
       <% else %>
-        <%= bar_chart @question.results.group(:answer_id).count %>
+        <%= bar_chart @question.result_data %>
       <% end %>
     </div>
 


### PR DESCRIPTION
The key here was `includes` called on a Question's `results`. You can read about `includes` under [Eager Loading Associations in the Rails Guides](http://guides.rubyonrails.org/active_record_querying.html#eager-loading-associations). By loading the answers for each result ahead of time, I could group on `answer`, not `answer_id`. This gave me a hash of answer => count when I called `.count` instead of answer_id => count.

Lastly, I made `to_s` on `Answer` give the content, so I wouldn't have to go through the hash and change each key to the content of that answer.

If this all makes sense, feel free to merge this. If you have questions, please post them on this pull request and I'll answer them when I have time.
